### PR TITLE
chagne cache generic type from record to value only

### DIFF
--- a/src/Cache.ts
+++ b/src/Cache.ts
@@ -6,13 +6,13 @@ import {
   comparator,
 } from './types';
 
-class Cache<T = Record<string, any>> implements CacheInterface<T> {
-  private _cache: Map<string, T[keyof T]>;
+class Cache<Value> implements CacheInterface<Value> {
+  private _cache: Map<string, Value>;
   private _listeners: cacheListener[];
-  private _comparator: comparator<T>;
+  private _comparator: comparator<Value>;
 
-  constructor(props: CacheConstructorInterface<T> = {}) {
-    this._cache = new Map(Object.entries<T[keyof T]>(props.initialData || {}));
+  constructor(props: CacheConstructorInterface<Value> = {}) {
+    this._cache = new Map(Object.entries<Value>(props.initialData || {}));
     this._listeners = props.listeners ? props.listeners : [];
     this._comparator = props.comparator ? props.comparator : () => true;
   }
@@ -21,7 +21,7 @@ class Cache<T = Record<string, any>> implements CacheInterface<T> {
     await Promise.all(this._listeners.map(async (listener) => await listener()));
   }
 
-  serializeKey(key: keyof T): serializeKeys<T> {
+  serializeKey(key: string): serializeKeys {
     const serializedKey = key;
     const errorKey = serializedKey ? 'error@' + serializedKey : '';
     return [serializedKey, errorKey];
@@ -54,14 +54,14 @@ class Cache<T = Record<string, any>> implements CacheInterface<T> {
     return this;
   }
 
-  delete(key: keyof T) {
+  delete(key: string) {
     const [serializedKey] = this.serializeKey(key);
     this._cache.delete(serializedKey as string);
     this.notify();
     return this;
   }
 
-  set(key: keyof T, value: T[keyof T]): any {
+  set(key: string, value: Value): this {
     const [serializedKey] = this.serializeKey(key);
     const prevValue = this._cache.get(serializedKey as string);
     const nextValue = value;
@@ -72,7 +72,7 @@ class Cache<T = Record<string, any>> implements CacheInterface<T> {
     return this;
   }
 
-  get(key: keyof T) {
+  get(key: string) {
     const [serializedKey] = this.serializeKey(key);
     const hitData = this._cache.get(serializedKey as string);
     if (!hitData) {
@@ -82,10 +82,10 @@ class Cache<T = Record<string, any>> implements CacheInterface<T> {
   }
 
   keys() {
-    return Array.from(this._cache.keys()) as (keyof T)[];
+    return Array.from(this._cache.keys()) as (string)[];
   }
 
-  has(key: keyof T) {
+  has(key: string) {
     const [serializedKey] = this.serializeKey(key);
     return this._cache.has(serializedKey as string);
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,22 +1,22 @@
 export type cacheListener = () => void;
-export type serializeKey<T> = keyof T | string;
-export type serializeKeys<T> = [serializeKey<T>, string];
+export type serializeKey = string;
+export type serializeKeys = [serializeKey, string];
 
-export type comparator<T> = (
-  key: keyof T,
-  prevValue?: T[keyof T],
-  nextValue?: T[keyof T],
+export type comparator<Value> = (
+  key: string,
+  prevValue?: Value,
+  nextValue?: Value,
 ) => boolean;
 
-export interface CacheInterface<T = Record<string, any>> {
+export interface CacheInterface<Value> {
   subscribe(listener: cacheListener): () => void;
   clear(): void;
-  delete(key: keyof T): void;
-  set(key: keyof T, value: T[keyof T]): any;
-  get(key: keyof T): T[keyof T] | null;
-  keys(): (keyof T)[];
-  has(key: keyof T): boolean;
-  serializeKey(key: keyof T): serializeKeys<T>;
+  delete(key: string): void;
+  set(key: string, value: Value): this;
+  get(key: string): Value | null;
+  keys(): (string)[];
+  has(key: string): boolean;
+  serializeKey(key: string): serializeKeys;
 }
 
 export interface CacheConstructorInterface<T> {

--- a/test/Cache.test.ts
+++ b/test/Cache.test.ts
@@ -1,6 +1,6 @@
 import Cache from '../src/Cache';
 
-type CacheProps = Record<string, any>
+type cacheValueType = any
 
 describe('Cache Test', () => {
   it('comparator', () => {
@@ -12,7 +12,7 @@ describe('Cache Test', () => {
       return true;
     };
     const initialData = { foo: 3 };
-    const cache = new Cache<CacheProps>({ initialData, comparator });
+    const cache = new Cache<cacheValueType>({ initialData, comparator });
     cache.set('user', { id: 1, name: 'seolhun' });
     cache.set('foo', 4);
     expect(cache.get('user')).toEqual({ id: 1, name: 'seolhun' });
@@ -24,7 +24,7 @@ describe('Cache Test', () => {
   });
 
   it('subscribe(): listener is not a function', () => {
-    const cache = new Cache<CacheProps>();
+    const cache = new Cache<cacheValueType>();
     try {
       cache.subscribe(null);
     } catch (error) {
@@ -33,7 +33,7 @@ describe('Cache Test', () => {
   });
 
   it('notify(): after set subscribe, log test', () => {
-    const cache = new Cache<CacheProps>();
+    const cache = new Cache<cacheValueType>();
     let subscribeOutput = 0;
     const subscribe = () => subscribeOutput++;
     cache.subscribe(subscribe);
@@ -49,7 +49,7 @@ describe('Cache Test', () => {
   });
 
   it('clear()', () => {
-    const cache = new Cache<CacheProps>();
+    const cache = new Cache<cacheValueType>();
     cache.set('user', {
       id: 1,
       name: 'hun',
@@ -58,7 +58,7 @@ describe('Cache Test', () => {
   });
 
   it('delete', () => {
-    const cache = new Cache<CacheProps>();
+    const cache = new Cache<cacheValueType>();
     cache.set('user', {
       id: 1,
       name: 'hun',
@@ -68,7 +68,7 @@ describe('Cache Test', () => {
   });
 
   it('set() - get()', () => {
-    const cache = new Cache<CacheProps>();
+    const cache = new Cache<cacheValueType>();
     cache.set('user', {
       id: 1,
       name: 'hun',
@@ -77,12 +77,12 @@ describe('Cache Test', () => {
   });
 
   it('get(): No cache key', () => {
-    const cache = new Cache<CacheProps>();
+    const cache = new Cache<cacheValueType>();
     expect(cache.get('foo')).toEqual(null);
   });
 
   it('keys()', () => {
-    const cache = new Cache<CacheProps>();
+    const cache = new Cache<cacheValueType>();
     expect(cache.keys()).toEqual([]);
     cache.set('user', {
       id: 1,
@@ -92,7 +92,7 @@ describe('Cache Test', () => {
   });
 
   it('has()', () => {
-    const cache = new Cache<CacheProps>();
+    const cache = new Cache<cacheValueType>();
     cache.set('user', {
       id: 1,
       name: 'hun',
@@ -103,7 +103,7 @@ describe('Cache Test', () => {
   });
 
   it('serializeKey()', () => {
-    const cache = new Cache<CacheProps>();
+    const cache = new Cache<cacheValueType>();
     expect(cache.serializeKey('user')).toEqual(['user', 'error@user']);
     expect(cache.serializeKey('foo')).toEqual(['foo', 'error@foo']);
   });


### PR DESCRIPTION
## Purpose

- Changed cache key `string`
- Changed cache generic type only `Value`

## Why

Cache must be acceptable any keys as string, because all values are not object.

## Related issue

- None.

## Additional context

- None.
